### PR TITLE
fix: use base URL env variable correctly

### DIFF
--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script setup>
-  const baseUrl = useRuntimeConfig().baseUrl;
+  const baseUrl = useRuntimeConfig().public.baseUrl;
 
   const copyToClipboard = (str) => {
     if (navigator && navigator.clipboard && navigator.clipboard.writeText)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,7 +51,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      baseUrl: process.env.URL
+      baseUrl: process.env.NUXT_PUBLIC_BASE_URL
     }
   }
 })


### PR DESCRIPTION
Fix the issue of `baseUrl` being `undefined`.

When deploying the app, please check that the env variable `NUXT_PUBLIC_BASE_URL` contains the actual hostname. I've set it to https://engagement.more-onion.com